### PR TITLE
Add 'configure-git' make target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -14,12 +14,22 @@ test:
 fmt:
 	find . -name "*.go" | grep -v -E "(.*/proto/.*|./*/mock/.*)" | xargs -I '{}' gofmt -s -w '{}'
 
+.PHONY: dev-mysql-up
 dev-mysql-up:
 	@docker compose \
 		-f docker/docker-compose-mysql.dev.yml \
 		up -d
 
+.PHONY: dev-mysql-down
 dev-mysql-down:
 	@docker compose \
 		-f docker/docker-compose-mysql.dev.yml \
 		down -v --rmi local
+
+# Set global git configuration to only replace our private dependencies with the SSH URL.
+.PHONY: configure-git
+configure-git:
+	git config --global url."git@github.com:sisu-network/deyes".insteadOf 'https://github.com/sisu-network/deyes'
+	git config --global url."git@github.com:sisu-network/dheart".insteadOf 'https://github.com/sisu-network/dheart'
+	git config --global url."git@github.com:sisu-network/lib".insteadOf 'https://github.com/sisu-network/lib'
+	git config --global url."git@github.com:sisu-network/tss-lib".insteadOf 'https://github.com/sisu-network/tss-lib'

--- a/README.md
+++ b/README.md
@@ -5,19 +5,7 @@
 - Install Go 1.6. Make sure GOPATH, GOROOT are set and go module is turned on.
 
 # Errors you might face.
-- A few depdencies of this project are private repo. You need to config git to use `git` instead of `https` when downloading repo.
-Run the following command to replace `https` by `git`.
-
-```
-git config --global url."git@github.com:".insteadOf "https://github.com/"
-```
-
-To confirm, do `more ~/.gitconfig` and make sure you see the following:
-
-```
-[url "git@github.com:"]
-	insteadOf = https://github.com/
-```
+- This repository currently depends on other private repositories in the sisu-network organization. Run `make configure-git` to tell git to clone those repositories over SSH.
 
 # Generate Mock structs
 

--- a/scripts/run_test.sh
+++ b/scripts/run_test.sh
@@ -7,7 +7,4 @@
 cd "$PROJECT_DIR" || exit 1
 
 echo_info "Test all packages"
-go test -race $(go list ./...)
-
-EXIT_CODE=$?
-exit $EXIT_CODE
+go test -race ./...


### PR DESCRIPTION
This saves the user from copying and pasting a more complicated
one-liner from the README.

And also fix some missing .PHONY labels in Makefile, and normalize the
run_test.sh script -- no need to call go list ./..., and no need to
store the exit code and explicitly exit with it. Bash and sh exit with
the code of the file's last command.
