### PR TITLE
Remove references to io/ioutil package

### DIFF
--- a/cmd/sisud/cmd/gen/local_docker.go
+++ b/cmd/sisud/cmd/gen/local_docker.go
@@ -3,7 +3,6 @@ package gen
 import (
 	"bytes"
 	"fmt"
-	"io/ioutil"
 	"math/big"
 	"os"
 	"path/filepath"
@@ -174,7 +173,7 @@ func cleanData(outputDir string) {
 		return
 	}
 
-	files, err := ioutil.ReadDir(outputDir)
+	files, err := os.ReadDir(outputDir)
 	if err != nil {
 		panic(err)
 	}

--- a/cmd/sisud/cmd/gen/testnet.go
+++ b/cmd/sisud/cmd/gen/testnet.go
@@ -3,7 +3,6 @@ package gen
 import (
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"strconv"
@@ -220,12 +219,12 @@ func (g *TestnetGenerator) generateHeartToml(index int, inputDir string, outputD
 
 func (g *TestnetGenerator) generateEyesToml(index int, inputDir string, outputDir string) {
 	// Simply copy the input file to the output file
-	data, err := ioutil.ReadFile(filepath.Join(inputDir, "deyes.toml"))
+	data, err := os.ReadFile(filepath.Join(inputDir, "deyes.toml"))
 	if err != nil {
 		panic(err)
 	}
 
-	err = ioutil.WriteFile(filepath.Join(outputDir, "deyes.toml"), data, 0644)
+	err = os.WriteFile(filepath.Join(outputDir, "deyes.toml"), data, 0644)
 	if err != nil {
 		panic(err)
 	}

--- a/cmd/sisud/cmd/gen/testnet_docker.go
+++ b/cmd/sisud/cmd/gen/testnet_docker.go
@@ -4,7 +4,6 @@ import (
 	"bytes"
 	"context"
 	"fmt"
-	"io/ioutil"
 	"math/big"
 	"os"
 	"path/filepath"
@@ -174,7 +173,7 @@ func (exe *TestnetDockerExecutor) cleanData(outputDir string) {
 		return
 	}
 
-	files, err := ioutil.ReadDir(outputDir)
+	files, err := os.ReadDir(outputDir)
 	if err != nil {
 		panic(err)
 	}

--- a/cmd/sisud/cmd/reset.go
+++ b/cmd/sisud/cmd/reset.go
@@ -3,7 +3,6 @@ package cmd
 import (
 	"database/sql"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"strings"
@@ -119,7 +118,7 @@ func resetValidatorState() error {
 	}`
 
 	path := app.MainAppHome + "/data/priv_validator_state.json"
-	return ioutil.WriteFile(path, []byte(content), 0644)
+	return os.WriteFile(path, []byte(content), 0644)
 }
 
 func deleteSql() error {

--- a/common/global_data.go
+++ b/common/global_data.go
@@ -3,7 +3,7 @@ package common
 import (
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
+	"os"
 	"sync"
 
 	"github.com/cosmos/cosmos-sdk/client/rpc"
@@ -61,7 +61,7 @@ func (a *GlobalDataDefault) Init() {
 	sisuConfig := a.cfg.Sisu
 
 	defaultConfigTomlFile := sisuConfig.Dir + "/config/config.toml"
-	data, err := ioutil.ReadFile(defaultConfigTomlFile)
+	data, err := os.ReadFile(defaultConfigTomlFile)
 	if err != nil {
 		panic(err)
 	}

--- a/config/default_toml.go
+++ b/config/default_toml.go
@@ -1,6 +1,6 @@
 package config
 
-import "io/ioutil"
+import "os"
 
 func writeDefaultTss(filePath string) error {
 	var defaultValue = `enable = false
@@ -8,7 +8,7 @@ dheart_host = "localhost"
 dheart_port = 5678
 [supported_chains]
 `
-	err := ioutil.WriteFile(filePath, []byte(defaultValue), 0644)
+	err := os.WriteFile(filePath, []byte(defaultValue), 0644)
 	if err != nil {
 		return err
 	}

--- a/utils/http.go
+++ b/utils/http.go
@@ -3,7 +3,7 @@ package utils
 import (
 	"errors"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
 
 	"github.com/hashicorp/go-retryablehttp"
@@ -21,7 +21,7 @@ func HttpGet(httpClient *retryablehttp.Client, url string) ([]byte, int, error) 
 		}
 	}()
 
-	buf, err := ioutil.ReadAll(resp.Body)
+	buf, err := io.ReadAll(resp.Body)
 	if resp.StatusCode != http.StatusOK {
 		return buf, resp.StatusCode, errors.New("Http get status is not ok: " + resp.Status)
 	}


### PR DESCRIPTION
As of go1.16 io/ioutil has been deprecated in favor of methods in the os
or io packages.