### PR TITLE
Fix crash because the world state is not initialized

### DIFF
--- a/app/bootstrapper.go
+++ b/app/bootstrapper.go
@@ -40,9 +40,6 @@ func (b *DefaultBootstrapper) BootstrapInternalNetwork(
 	encryptedAes []byte,
 	tendermintKeyType string,
 ) (tssclients.DheartClient, tssclients.DeyesClient) {
-	apiHandler.SetNetworkHealthListener(b)
-	b.waitForPing()
-
 	// Dheart
 	var dheartClient tssclients.DheartClient
 	var err error
@@ -97,28 +94,4 @@ func (b *DefaultBootstrapper) BootstrapInternalNetwork(
 	}
 
 	return dheartClient, deyesClient
-}
-
-// waitForPing waits for ping from dheart and deyes.
-func (b *DefaultBootstrapper) waitForPing() {
-	for {
-		if b.dheartConnected.Load() == true && b.deyesConnected.Load() == true {
-			break
-		}
-		time.Sleep(RETRY_TIMEOUT)
-	}
-	log.Info("Received both pings from deyes and dheart")
-}
-
-func (b *DefaultBootstrapper) OnPing(source string) {
-	switch source {
-	case "dheart":
-		log.Info("Received ping from dheart")
-		b.dheartConnected.Store(true)
-	case "deyes":
-		log.Info("Received ping from deyes")
-		b.deyesConnected.Store(true)
-	default:
-		log.Error("unkonwn source: ", source)
-	}
 }

--- a/x/sisu/processor.go
+++ b/x/sisu/processor.go
@@ -93,6 +93,7 @@ func NewProcessor(k keeper.DefaultKeeper,
 func (p *Processor) Init() {
 	log.Info("Initializing TSS Processor...")
 
+	p.worldState = NewWorldState(p.config, p.publicDb, p.deyesClient)
 	p.txOutputProducer = NewTxOutputProducer(p.worldState, p.appKeys, p.publicDb, p.privateDb, p.config)
 }
 
@@ -114,6 +115,7 @@ func (p *Processor) BeginBlock(ctx sdk.Context, blockHeight int64) {
 		log.Info("Setting Sisu readiness for dheart.")
 		// This node has fully catched up with the blockchain, we need to inform dheart about this.
 		p.dheartClient.SetSisuReady(true)
+		p.deyesClient.SetSisuReady(true)
 	}
 
 	// TODO: Make keygen to be command instead of embedding inside the code.

--- a/x/sisu/tssclients/deyes_client.go
+++ b/x/sisu/tssclients/deyes_client.go
@@ -13,6 +13,7 @@ type DeyesClient interface {
 	Dispatch(request *eTypes.DispatchedTxRequest) (*eTypes.DispatchedTxResult, error)
 	AddWatchAddresses(chain string, addrs []string) error
 	GetNonce(chain string, address string) int64
+	SetSisuReady(isReady bool) error
 }
 
 type DefaultDeyesClient struct {
@@ -47,11 +48,11 @@ func (c *DefaultDeyesClient) Ping(source string) error {
 }
 
 // Informs the deyes that Sisu server is ready to accept transaction.
-func (c *DefaultDeyesClient) SetSisuReady(chain string) error {
+func (c *DefaultDeyesClient) SetSisuReady(isReady bool) error {
 	var result string
-	err := c.client.CallContext(context.Background(), &result, "deyes_setSisuReady", chain)
+	err := c.client.CallContext(context.Background(), &result, "deyes_setSisuReady", isReady)
 	if err != nil {
-		log.Error("Cannot Set readiness for deyes, chain = ", chain, "err = ", err)
+		log.Error("Cannot Set readiness for deyes, err = ", err)
 		return err
 	}
 

--- a/x/sisu/tx_out_producer.go
+++ b/x/sisu/tx_out_producer.go
@@ -160,6 +160,7 @@ func (p *DefaultTxOutputProducer) getEthContractDeploymentTx(ctx sdk.Context, he
 			log.Error("cannot get nonce for contract")
 			continue
 		}
+
 		rawTx := p.getContractTx(contract, nonce)
 		if rawTx == nil {
 			log.Warn("raw Tx is nil")


### PR DESCRIPTION
- Fix crash because of missing world state initialization.
- Remove waiting for dheart and deyes at bootstrapping.
