### PR TITLE
Refactor to simplify fund-account

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,7 +100,7 @@ You can now deploy ETH transaction on ganache1 at port 7545.
 Run this command to fund 2 gateway smart contract on 2 different chains ganache1 and ganache2:
 
 ```
-./sisu dev fund-account ganache1 7545 ganache2 8545 10
+./sisu dev fund-account
 ```
 
 This command does a number of things:

--- a/cmd/sisud/cmd/flags/flags.go
+++ b/cmd/sisud/cmd/flags/flags.go
@@ -1,7 +1,10 @@
 package flags
 
 const (
-	Chain = "chain"
-	Name  = "name"
-	Index = "index"
+	Chain     = "chain"
+	Name      = "name"
+	Index     = "index"
+	Chains    = "chains"
+	ChainUrls = "chain-urls"
+	Amount    = "amount"
 )


### PR DESCRIPTION
Refactor `fund-account` command to not deploy contracts again if they have been deployed on ganache. This allows dev not have to restart ganache again even when we restart sisu. 