### PR TITLE
Rewrite TxOutProducerTest using test context

### DIFF
--- a/app/app.go
+++ b/app/app.go
@@ -261,7 +261,7 @@ func New(
 	// storage that contains common data for all the nodes
 	privateDb := keeper.NewStorageDb(filepath.Join(cfg.Sisu.Dir, "private"))
 
-	worldState := world.NewWorldState(tssConfig, app.tssKeeper, deyesClient)
+	worldState := world.NewWorldState(app.tssKeeper, deyesClient)
 	txTracker := tss.NewTxTracker(cfg.Sisu.EmailAlert, worldState)
 
 	mc := tss.NewManagerContainer(tss.NewPostedMessageManager(app.tssKeeper),

--- a/common/mock.go
+++ b/common/mock.go
@@ -1,0 +1,57 @@
+package common
+
+import (
+	"encoding/hex"
+
+	keyring "github.com/cosmos/cosmos-sdk/crypto/keyring"
+	sdk "github.com/cosmos/cosmos-sdk/types"
+	"github.com/sisu-network/sisu/utils"
+	tcrypto "github.com/tendermint/tendermint/crypto"
+	"github.com/tendermint/tendermint/crypto/ed25519"
+)
+
+type MockAppKeys struct {
+	privKey tcrypto.PrivKey
+	addr    sdk.AccAddress
+}
+
+func NewMockAppKeys() AppKeys {
+	bz, err := hex.DecodeString("fd914bab512acb5d8fdd5537146339fdf8bbd141f9cba3c039b8d732188b0d6a62c5713923f2e087ce62554b07d738c07363d84edfc4a3e05c4e65e0")
+	if err != nil {
+		panic(err)
+	}
+
+	addr, err := sdk.AccAddressFromBech32("cosmos1qhktedg5njrjc8xy97m9y9vwnvg9atrk3sru7y")
+	if err != nil {
+		panic(err)
+	}
+
+	privKey := ed25519.PrivKey(bz)
+	return &MockAppKeys{
+		privKey: privKey,
+		addr:    addr,
+	}
+}
+
+func (ak *MockAppKeys) Init() {
+}
+
+func (ak *MockAppKeys) GetSignerInfo() keyring.Info {
+	return nil
+}
+
+func (ak *MockAppKeys) GetSignerAddress() sdk.AccAddress {
+	return ak.addr
+}
+
+func (ak *MockAppKeys) GetKeyring() keyring.Keyring {
+	panic("Unsupported")
+}
+
+func (ak *MockAppKeys) GetEncryptedPrivKey() ([]byte, error) {
+	return ak.privKey.Bytes(), nil
+}
+
+func (ak *MockAppKeys) GetAesEncrypted(msg []byte) ([]byte, error) {
+	return utils.AESDEncrypt(msg, ak.privKey.Bytes())
+}

--- a/x/sisu/test_helpers.go
+++ b/x/sisu/test_helpers.go
@@ -1,0 +1,160 @@
+package sisu
+
+import (
+	"crypto/ecdsa"
+	"encoding/hex"
+	"math/big"
+
+	"github.com/cosmos/cosmos-sdk/store"
+	sdk "github.com/cosmos/cosmos-sdk/types"
+	ecommon "github.com/ethereum/go-ethereum/common"
+	ethTypes "github.com/ethereum/go-ethereum/core/types"
+	"github.com/ethereum/go-ethereum/crypto"
+	libchain "github.com/sisu-network/lib/chain"
+	"github.com/sisu-network/sisu/x/sisu/keeper"
+	"github.com/sisu-network/sisu/x/sisu/tssclients"
+	"github.com/sisu-network/sisu/x/sisu/types"
+	"github.com/sisu-network/sisu/x/sisu/world"
+	tlog "github.com/tendermint/tendermint/libs/log"
+	tmproto "github.com/tendermint/tendermint/proto/tendermint/types"
+	dbm "github.com/tendermint/tm-db"
+)
+
+var (
+	testKeyStore          = sdk.NewKVStoreKey("TestContext")
+	testSisuEthAddr       = "0x743E1388AAd8EC7c47Df39AFbAEd58EBc1f43901"
+	testSisuEthPubkeyHex  = "04b3cb1c95782b1793e3102d2ba493c34456f11ce471ca7e1ec1a731275b72bb2ba93e45069dab6d2b84815baeb3824f39c344bb9cf03d62cca9504724a808cc42"
+	testContractAddr      = "0x50cc7ceDe8532d5f431EfC3e3EF167423Bc1807a"
+	testErc20TokenAddress = "0x3A84fBbeFD21D6a5ce79D54d348344EE11EBd45C"
+)
+
+func testContext() sdk.Context {
+	db := dbm.NewMemDB()
+	cms := store.NewCommitMultiStore(db)
+	cms.MountStoreWithDB(testKeyStore, sdk.StoreTypeIAVL, db)
+	cms.LoadVersion(0)
+	ctx := sdk.NewContext(cms, tmproto.Header{}, false, tlog.NewNopLogger())
+	return ctx
+}
+
+// Default keeper
+func keeperTestGenesis(ctx sdk.Context) keeper.Keeper {
+	keeper := keeper.NewKeeper(testKeyStore)
+	keeper.SaveChain(ctx, &types.Chain{
+		Id:       "ganache1",
+		GasPrice: int64(5_000_000_000),
+	})
+	keeper.SaveChain(ctx, &types.Chain{
+		Id:       "ganache2",
+		GasPrice: int64(10_000_000_000),
+	})
+	liquidities := map[string]*types.Liquidity{
+		"ganache1": {
+			Id:      "ganache1",
+			Address: "0xf0D676183dD5ae6b370adDdbE770235F23546f9d",
+		},
+		"ganache2": {
+			Id:      "ganache2",
+			Address: "0xf0D676183dD5ae6b370adDdbE770235F23546f9d",
+		},
+	}
+	keeper.SetLiquidities(ctx, liquidities)
+	keeper.SetTokens(ctx, map[string]*types.Token{
+		"NATIVE_GANACHE1": {
+			Id:       "NATIVE_GANACHE1",
+			Price:    2000000000,
+			Decimals: 18,
+		},
+		"NATIVE_GANACHE2": {
+			Id:       "NATIVE_GANACHE1",
+			Price:    2000000000,
+			Decimals: 18,
+		},
+		"SISU": {
+			Id:        "SISU",
+			Price:     4000000000,
+			Decimals:  18,
+			Chains:    []string{"ganache1", "ganache2"},
+			Addresses: []string{testErc20TokenAddress, testErc20TokenAddress},
+		},
+	})
+	return keeper
+}
+
+// Keeper after keygen has been saved
+func keeperTestAfterKeygen(ctx sdk.Context) keeper.Keeper {
+	ethTx := defaultTestEthTx(0)
+	keeper := keeperTestGenesis(ctx)
+
+	keeper.SaveKeygen(ctx, &types.Keygen{
+		KeyType:     libchain.KEY_TYPE_ECDSA,
+		Address:     ethTx.To().String(),
+		PubKeyBytes: defaultTestEthPubkeyBytes(),
+	})
+	keeper.SaveContract(ctx, &types.Contract{
+		Chain: "ganache1",
+		Name:  "erc20gateway",
+		Hash:  SupportedContracts[ContractErc20Gateway].AbiHash,
+	}, false)
+	keeper.SaveContract(ctx, &types.Contract{
+		Chain: "ganache2",
+		Name:  "erc20gateway",
+		Hash:  SupportedContracts[ContractErc20Gateway].AbiHash,
+	}, false)
+
+	return keeper
+}
+
+func keeperTestAfterContractDeployed(ctx sdk.Context) keeper.Keeper {
+	keeper := keeperTestAfterKeygen(ctx)
+
+	keeper.SaveContract(ctx, &types.Contract{
+		Chain:   "ganache1",
+		Name:    "erc20gateway",
+		Address: testContractAddr,
+		Hash:    SupportedContracts[ContractErc20Gateway].AbiHash,
+	}, false)
+	keeper.SaveContract(ctx, &types.Contract{
+		Chain:   "ganache2",
+		Name:    "erc20gateway",
+		Address: testContractAddr,
+		Hash:    SupportedContracts[ContractErc20Gateway].AbiHash,
+	}, false)
+
+	return keeper
+}
+
+func defaultTestEthPubkeyBytes() []byte {
+	bz, err := hex.DecodeString(testSisuEthPubkeyHex)
+	if err != nil {
+		panic(err)
+	}
+
+	return bz
+}
+
+func defaultTestEthPubkey() *ecdsa.PublicKey {
+	bz := defaultTestEthPubkeyBytes()
+
+	pubkey, err := crypto.UnmarshalPubkey(bz)
+	if err != nil {
+		panic(err)
+	}
+	return pubkey
+}
+
+func defaultTestEthTx(nonce uint64) *ethTypes.Transaction {
+	amount := big.NewInt(100)
+	gasLimit := uint64(100)
+	gasPrice := big.NewInt(100)
+
+	return ethTypes.NewTransaction(nonce,
+		ecommon.HexToAddress("0x743E1388AAd8EC7c47Df39AFbAEd58EBc1f43901"), amount, gasLimit, gasPrice, nil)
+}
+
+func defaultWorldStateTest(ctx sdk.Context, keeper keeper.Keeper, deyesClients tssclients.DeyesClient) world.WorldState {
+	ws := world.NewWorldState(keeper, deyesClients)
+	ws.InitData(ctx)
+
+	return ws
+}

--- a/x/sisu/tssclients/deyes_client.go
+++ b/x/sisu/tssclients/deyes_client.go
@@ -16,7 +16,7 @@ type DeyesClient interface {
 	SetSisuReady(isReady bool) error
 }
 
-type DefaultDeyesClient struct {
+type defaultDeyesClient struct {
 	client *rpc.Client
 }
 
@@ -33,10 +33,10 @@ func dialDeyesContext(ctx context.Context, rawurl string) (DeyesClient, error) {
 }
 
 func newDeyesClient(c *rpc.Client) DeyesClient {
-	return &DefaultDeyesClient{c}
+	return &defaultDeyesClient{c}
 }
 
-func (c *DefaultDeyesClient) Ping(source string) error {
+func (c *defaultDeyesClient) Ping(source string) error {
 	var result interface{}
 	err := c.client.CallContext(context.Background(), &result, "deyes_ping", source)
 	if err != nil {
@@ -48,7 +48,7 @@ func (c *DefaultDeyesClient) Ping(source string) error {
 }
 
 // Informs the deyes that Sisu server is ready to accept transaction.
-func (c *DefaultDeyesClient) SetSisuReady(isReady bool) error {
+func (c *defaultDeyesClient) SetSisuReady(isReady bool) error {
 	var result string
 	err := c.client.CallContext(context.Background(), &result, "deyes_setSisuReady", isReady)
 	if err != nil {
@@ -60,7 +60,7 @@ func (c *DefaultDeyesClient) SetSisuReady(isReady bool) error {
 }
 
 // Adds a list of addresses to watch on a specific chain
-func (c *DefaultDeyesClient) AddWatchAddresses(chain string, addrs []string) error {
+func (c *defaultDeyesClient) AddWatchAddresses(chain string, addrs []string) error {
 	var result string
 	err := c.client.CallContext(context.Background(), &result, "deyes_addWatchAddresses", chain, addrs)
 	if err != nil {
@@ -71,7 +71,7 @@ func (c *DefaultDeyesClient) AddWatchAddresses(chain string, addrs []string) err
 	return nil
 }
 
-func (c *DefaultDeyesClient) Dispatch(request *eTypes.DispatchedTxRequest) (*eTypes.DispatchedTxResult, error) {
+func (c *defaultDeyesClient) Dispatch(request *eTypes.DispatchedTxRequest) (*eTypes.DispatchedTxResult, error) {
 	var result = &eTypes.DispatchedTxResult{}
 	err := c.client.CallContext(context.Background(), &result, "deyes_dispatchTx", request)
 	if err != nil {
@@ -84,7 +84,7 @@ func (c *DefaultDeyesClient) Dispatch(request *eTypes.DispatchedTxRequest) (*eTy
 	return result, nil
 }
 
-func (c *DefaultDeyesClient) GetNonce(chain string, address string) int64 {
+func (c *defaultDeyesClient) GetNonce(chain string, address string) int64 {
 	var result int64
 	err := c.client.CallContext(context.Background(), &result, "deyes_getNonce", chain, address)
 	if err != nil {

--- a/x/sisu/tssclients/mock.go
+++ b/x/sisu/tssclients/mock.go
@@ -1,0 +1,51 @@
+package tssclients
+
+import eTypes "github.com/sisu-network/deyes/types"
+
+type MockDeyesClient struct {
+	PingFunc              func(source string) error
+	DispatchFunc          func(request *eTypes.DispatchedTxRequest) (*eTypes.DispatchedTxResult, error)
+	AddWatchAddressesFunc func(chain string, addrs []string) error
+	GetNonceFunc          func(chain string, address string) int64
+	SetSisuReadyFunc      func(isReady bool) error
+}
+
+func (c *MockDeyesClient) Ping(source string) error {
+	if c.PingFunc != nil {
+		return c.PingFunc(source)
+	}
+
+	return nil
+}
+
+func (c *MockDeyesClient) Dispatch(request *eTypes.DispatchedTxRequest) (*eTypes.DispatchedTxResult, error) {
+	if c.DispatchFunc != nil {
+		return c.DispatchFunc(request)
+	}
+
+	return nil, nil
+}
+
+func (c *MockDeyesClient) AddWatchAddresses(chain string, addrs []string) error {
+	if c.AddWatchAddressesFunc != nil {
+		return c.AddWatchAddressesFunc(chain, addrs)
+	}
+
+	return nil
+}
+
+func (c *MockDeyesClient) GetNonce(chain string, address string) int64 {
+	if c.GetNonceFunc != nil {
+		return c.GetNonceFunc(chain, address)
+	}
+
+	return 0
+}
+
+func (c *MockDeyesClient) SetSisuReady(isReady bool) error {
+	if c.SetSisuReadyFunc != nil {
+		return c.SetSisuReadyFunc(isReady)
+	}
+
+	return nil
+}

--- a/x/sisu/tx_out_producer.go
+++ b/x/sisu/tx_out_producer.go
@@ -131,7 +131,6 @@ func (p *DefaultTxOutputProducer) getEthResponse(ctx sdk.Context, height int64, 
 	// 2. Check if this is a tx sent to one of our contracts.
 	if ethTx.To() != nil &&
 		p.keeper.IsContractExistedAtAddress(ctx, tx.Chain, ethTx.To().String()) && len(ethTx.Data()) >= 4 {
-
 		// TODO: compare method name to trigger corresponding contract method
 		responseTx, err := p.processERC20TransferOut(ctx, ethTx)
 		if err != nil {

--- a/x/sisu/world/world_state.go
+++ b/x/sisu/world/world_state.go
@@ -8,7 +8,6 @@ import (
 	"github.com/ethereum/go-ethereum/crypto"
 	libchain "github.com/sisu-network/lib/chain"
 	"github.com/sisu-network/lib/log"
-	"github.com/sisu-network/sisu/config"
 	"github.com/sisu-network/sisu/x/sisu/helper"
 	"github.com/sisu-network/sisu/x/sisu/keeper"
 	"github.com/sisu-network/sisu/x/sisu/tssclients"
@@ -63,7 +62,6 @@ type WorldState interface {
 
 type DefaultWorldState struct {
 	keeper      keeper.Keeper
-	tssConfig   config.TssConfig
 	nonces      map[string]int64
 	deyesClient tssclients.DeyesClient
 
@@ -73,11 +71,8 @@ type DefaultWorldState struct {
 	addrToToken *sync.Map // chain__addr => *types.Token
 }
 
-func NewWorldState(tssConfig config.TssConfig, keeper keeper.Keeper,
-	deyesClients tssclients.DeyesClient) WorldState {
-
+func NewWorldState(keeper keeper.Keeper, deyesClients tssclients.DeyesClient) WorldState {
 	return &DefaultWorldState{
-		tssConfig:   tssConfig,
 		keeper:      keeper,
 		nonces:      make(map[string]int64, 0),
 		deyesClient: deyesClients,


### PR DESCRIPTION
Previous TxOutProducerTest uses mockgen to generate mock for tests. This PR replaces mockgen with real keeper and in-memory context to better test the app.