### PR TITLE
bugfix: when dheart signing fails, a validator node should submit TxOutResult failure

### DIFF
--- a/cmd/sisud/cmd/dev/stress_swap.go
+++ b/cmd/sisud/cmd/dev/stress_swap.go
@@ -40,12 +40,11 @@ var (
 		"avaxc-testnet__binance-testnet",
 		"avaxc-testnet__goerli-testnet",
 		"avaxc-testnet__polygon-testnet",
-		// "avaxc-testnet__solana-devnet",
 
-		// "binance-testnet__fantom-testnet",
-		// "binance-testnet__avaxc-testnet",
-		// "binance-testnet__goerli-testnet",
+		// "avaxc-testnet__polygon-testnet",
 		// "binance-testnet__polygon-testnet",
+		// "goerli-testnet__polygon-testnet",
+		// "polygon-testnet__polygon-testnet",
 		// "binance-testnet__solana-devnet",
 	}
 )

--- a/x/sisu/api_handler.go
+++ b/x/sisu/api_handler.go
@@ -200,8 +200,18 @@ func (a *ApiHandler) OnKeysignResult(result *dhtypes.KeysignResult) {
 	}
 
 	if result.Outcome == dhtypes.OutcomeFailure {
-		// TODO: Report failure and culprits here.
-		log.Warn("Dheart signing failed")
+		// TODO: find the culprits here.
+		for _, keysignMsg := range result.Request.KeysignMessages {
+			log.Warn("Dheart signing failed for chain %s, hash = %s", keysignMsg.OutChain,
+				keysignMsg.OutHash)
+			txOutResult := &types.TxOutResult{
+				Result:   types.TxOutResultType_IN_BLOCK_FAILURE,
+				TxOutId:  types.GetTxOutIdFromChainAndHash(keysignMsg.OutChain, keysignMsg.OutHash),
+				OutChain: keysignMsg.OutChain,
+				OutHash:  keysignMsg.OutHash,
+			}
+			a.submitTxOutResult(txOutResult)
+		}
 		return
 	}
 

--- a/x/sisu/background/sign_tx.go
+++ b/x/sisu/background/sign_tx.go
@@ -45,7 +45,8 @@ func SignTxOut(ctx sdk.Context, dheartClient external.DheartClient,
 // signEthTx sends a TxOut to dheart for TSS signing.
 func signEthTx(ctx sdk.Context, dheartClient external.DheartClient, pubKeys []cosmoscrypto.PubKey,
 	tx *types.TxOut) error {
-	log.Info("Delivering TXOUT for chain ", tx.Content.OutChain, " tx hash = ", tx.Content.OutHash)
+	log.Infof("Signing transaction for chain %s (not signed) hash = %s", tx.Content.OutChain,
+		tx.Content.OutHash)
 	ethTx := &ethtypes.Transaction{}
 	err := ethTx.UnmarshalBinary(tx.Content.OutBytes)
 	if err != nil {

--- a/x/sisu/handler_tx_out_proposal.go
+++ b/x/sisu/handler_tx_out_proposal.go
@@ -61,7 +61,7 @@ func (h *HandlerTxOutProposal) DeliverMsg(ctx sdk.Context, msg *types.TxOutMsg) 
 // doTxOut saves a TxOut in the keeper and add it the TxOut Queue.
 func doTxOut(ctx sdk.Context, k keeper.Keeper, privateDb keeper.PrivateDb,
 	txOut *types.TxOut) ([]byte, error) {
-	log.Info("Delivering TxOut")
+	log.Info("Finalizing TxOut, id = ", txOut.GetId())
 
 	// Save this to KVStore
 	k.SetFinalizedTxOut(ctx, txOut.GetId(), txOut)

--- a/x/sisu/keeper/grpc_query.go
+++ b/x/sisu/keeper/grpc_query.go
@@ -7,6 +7,8 @@ import (
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	"github.com/sisu-network/lib/log"
 	"github.com/sisu-network/sisu/x/sisu/types"
+
+	libchain "github.com/sisu-network/lib/chain"
 )
 
 type GrpcQuerier struct {
@@ -23,6 +25,9 @@ func (k *GrpcQuerier) AllPubKeys(goCtx context.Context, req *types.QueryAllPubKe
 	log.Verbose("Fetching all pub keys.")
 
 	allPubKeys := k.keeper.GetAllKeygenPubkeys(ctx)
+	if allPubKeys[libchain.KEY_TYPE_ECDSA] == nil || allPubKeys[libchain.KEY_TYPE_EDDSA] == nil {
+		return nil, fmt.Errorf("Pubkey is not ready")
+	}
 
 	return &types.QueryAllPubKeysResponse{
 		Pubkeys: allPubKeys,


### PR DESCRIPTION
This bug happens because a leader node cannot find enough participants for signing a message (other nodes are busy signing other transactions). We need to figure out a retry mechanism for failing signing messages. 

This PR simply submits TxOutResult failure to the network.